### PR TITLE
make `reshape` available in the public api

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+from arabic_reshaper import reshape
+
+__all__=[reshape] 


### PR DESCRIPTION
Users used to do:

     import arabic_reshaper
     arabic_reshaper.reshape()

instead of:

      from arabic_reshaper import arabic_reshaper
     arabic_reshaper.reshape()

so not to break what they used to, I added reshape to root. If you want to move all , I will change it in `__init__.py` to:

     from arabic_reshaper import *

