### PR TITLE
PKG: Add setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     platforms="ALL",
     license="GPL",
     packages=['arabic_reshaper'],
-    install_requires=['configparser', 'future'],
+    install_requires=['configparser', 'future', 'setuptools'],
     author="Abdullah Diab",
     author_email="mpcabd@gmail.com",
     maintainer="Abdullah Diab",


### PR DESCRIPTION
`arabic_reshaper.py` makes use of `pkg_resources`, which is part of `setuptools` (which, in turn, is not part of the Python standard library).