### PR TITLE
ResourceWarning: __init__.py

### DIFF
--- a/arabic_reshaper/__init__.py
+++ b/arabic_reshaper/__init__.py
@@ -9,4 +9,5 @@ from .reshaper_config import (config_for_true_type_font,
                               ENABLE_ALL_LIGATURES)
 
 
-exec(open(os.path.join(os.path.dirname(__file__), '__version__.py')).read())
+with open(os.path.join(os.path.dirname(__file__), '__version__.py')) as fh:
+    exec(fh.read())


### PR DESCRIPTION
Opening a file - without closing it later - will keep the file open. By using "with-as" this won't happen.

Reason I'm submitting this PR:
Whenever I run "import arabic_reshaper" in my scripts together with -W default -X tracemalloc=25 as arguments for Python, it'll show me that there is a ResourceWarning in your __ini__.py file.

C:\Users\XXX\Desktop\test\lib\site-packages\arabic_reshaper\__init__.py:12: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Users\\XXX\\Desktop\\test\\lib\\site-packages\\arabic_reshaper\\__version__.py' mode='r' encoding='cp1252'>
  exec(open(os.path.join(os.path.dirname(__file__), '__version__.py')).read())
Object allocated at (most recent call last):
  File "C:/Users/XXX/Desktop/test/scratch.py", lineno 3
    import arabic_reshaper
  File "<frozen importlib._bootstrap>", lineno 991
  File "<frozen importlib._bootstrap>", lineno 975
  File "<frozen importlib._bootstrap>", lineno 671
  File "<frozen importlib._bootstrap_external>", lineno 783
  File "<frozen importlib._bootstrap>", lineno 219
  File "C:\Users\XXX\Desktop\test\lib\site-packages\arabic_reshaper\__init__.py", lineno 12
    exec(open(os.path.join(os.path.dirname(__file__), '__version__.py')).read())