### PR TITLE
fix: remove unused import from pkg_resources

### DIFF
--- a/arabic_reshaper/reshaper_config.py
+++ b/arabic_reshaper/reshaper_config.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals
 import os
 
 from configparser import ConfigParser
-from pkg_resources import resource_filename
 
 from .letters import (UNSHAPED, ISOLATED, LETTERS_ARABIC)
 from .ligatures import (SENTENCES_LIGATURES,

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setup(
     license="MIT",
     packages=['arabic_reshaper'],
     install_requires=['configparser; python_version <"3"',
-                      'future',
-                      'setuptools'],
+                      'future'],
     extras_require={
         'with-fonttools': ['fonttools>=4.0; python_version >="3"',
                            'fonttools>=3.0,<4.0; python_version <"3"']


### PR DESCRIPTION
Removing the unused import allows to remove setuptools from install_requires.
Fixes #77.