### PR TITLE
Update reshaper_config.py

### DIFF
--- a/arabic_reshaper/reshaper_config.py
+++ b/arabic_reshaper/reshaper_config.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals
 import os
 
 from configparser import ConfigParser
-from pkg_resources import resource_filename
 
 from .letters import (UNSHAPED, ISOLATED, LETTERS_ARABIC)
 from .ligatures import (SENTENCES_LIGATURES,


### PR DESCRIPTION
removed unused `from pkg_resources import resource_filename`
This causes an error "AttributeError: 'PosixPath' object has no attribute 'startswith'" on python devcontainer docker container.